### PR TITLE
Add the most common vim files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@
 venv
 pyvenv.cfg
 lib64
+
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]sw[a-p]
+
+# Persistent undo
+[._]*.un~


### PR DESCRIPTION
Reference: https://github.com/github/gitignore/blob/main/Global/Vim.gitignore